### PR TITLE
Fix nonexisting support_kilt branch for jbuilder

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,6 @@ license: MIT
 dependencies:
   jbuilder:
     github: shootingfly/jbuilder
-    branch: support_kilt
   kilt:
     github: shootingfly/kilt
     branch: support_jbuilder


### PR DESCRIPTION
Currently this does not run because the `support_kilt` branch is no longer